### PR TITLE
feature/SOF-7570 update: start using pydantic

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8.6]
+        python-version: [3.10.13]
 
     steps:
       - name: Checkout this repository
@@ -37,10 +37,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8.x
-          - 3.9.x
           - 3.10.x
           - 3.11.x
+          - 3.12.x
 
     steps:
       - name: Checkout this repository

--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/
@@ -176,3 +176,4 @@ node_modules/
 *.DS_Store
 
 tsconfig.tsbuildinfo
+.python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     # add requirements here
     "numpy",
     "jsonschema>=2.6.0",
+    "pydantic>=2.10.5",
     "mat3ra-utils>=2024.5.15.post0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ dynamic = ["version"]
 description = "COre DEfinitions."
 readme = "README.md"
 requires-python = ">=3.8"
-license = {file = "LICENSE.md"}
+license = { file = "LICENSE.md" }
 authors = [
-    {name = "Exabyte Inc.", email = "info@mat3ra.com"}
+    { name = "Exabyte Inc.", email = "info@mat3ra.com" }
 ]
 classifiers = [
     "Programming Language :: Python",
@@ -19,6 +19,7 @@ dependencies = [
     "numpy",
     "jsonschema>=2.6.0",
     "pydantic>=2.10.5",
+    "mat3ra-esse @ git+https://github.com/Exabyte-io/esse.git@refs/pull/325/head",
     "mat3ra-utils>=2024.5.15.post0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,11 @@ target-version = "py38"
 profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.pytest.ini_options]
+pythonpath = [
+    "src/py",
+]
+testpaths = [
+    "tests/py"
+]

--- a/src/py/mat3ra/__init__.py
+++ b/src/py/mat3ra/__init__.py
@@ -1,0 +1,2 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+# otherwise, `mat3ra.utils` path leads to an empty __init__.py file in the code.py package

--- a/src/py/mat3ra/__init__.py
+++ b/src/py/mat3ra/__init__.py
@@ -1,2 +1,2 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 # otherwise, `mat3ra.utils` path leads to an empty __init__.py file in the code.py package

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -37,7 +37,7 @@ class InMemoryEntityPydantic(BaseModel):
 
     @classmethod
     def create(cls: Type[T], config: Dict[str, Any]) -> T:
-        return cls.validate(**config)
+        return cls.validate(config)
 
     @classmethod
     def validate(cls, value: Any) -> Self:

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -7,9 +7,11 @@ from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, Nam
 
 T = TypeVar("T", bound="InMemoryEntity")
 
+
 class InMemoryEntity(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = {
+        "arbitrary_types_allowed": True
+    }
 
     @classmethod
     def get_cls(cls) -> str:
@@ -21,12 +23,6 @@ class InMemoryEntity(BaseModel):
     @property
     def id(self) -> str:
         return self.model_fields.get("_id", {}).get("default", "")
-
-    def get_as_entity_reference(self, by_id_only: bool = False) -> Dict[str, str]:
-        base = {"_id": self.id}
-        if not by_id_only:
-            base.update({"cls": self.get_cls_name()})
-        return base
 
     def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
         return self.model_dump(exclude=set(exclude) if exclude else None)

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional, Type, TypeVar
-from typing_extensions import Self
 
 import jsonschema
 from mat3ra.utils import object as object_utils
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from . import BaseUnderscoreJsonPropsHandler
 from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
@@ -39,7 +39,7 @@ class InMemoryEntityPydantic(BaseModel):
     def create(cls: Type[T], config: Dict[str, Any]) -> T:
         validated_data = cls.clean(config)
         return cls(**validated_data)
-    
+
     @classmethod
     def validate(cls, value: Any) -> Self:
         return cls.model_validate(value)

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -1,13 +1,11 @@
-from typing import Any, Dict, List, Optional, TypeVar
-
-from pydantic import BaseModel
-
-from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import jsonschema
 from mat3ra.utils import object as object_utils
+from pydantic import BaseModel
 
 from . import BaseUnderscoreJsonPropsHandler
+from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
 
 T = TypeVar("T", bound="InMemoryEntityPydantic")
 
@@ -34,9 +32,7 @@ class EntityError(Exception):
 
 
 class InMemoryEntityPydantic(BaseModel):
-    model_config = {
-        "arbitrary_types_allowed": True
-    }
+    model_config = {"arbitrary_types_allowed": True}
 
     @classmethod
     def get_cls(cls) -> str:
@@ -52,11 +48,11 @@ class InMemoryEntityPydantic(BaseModel):
         return self.model_dump_json(exclude=set(exclude) if exclude else None)
 
     @classmethod
-    def create(cls: type[T], config: Dict[str, Any]) -> T:
+    def create(cls: Type[T], config: Dict[str, Any]) -> T:
         return cls(**config)
 
     @classmethod
-    def from_json(cls: type[T], json_str: str) -> T:
+    def from_json(cls: Type[T], json_str: str) -> T:
         return cls.model_validate_json(json_str)
 
     def clone(self: T, extra_context: Optional[Dict[str, Any]] = None) -> T:

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypeVar
 
 import jsonschema
-from mat3ra.utils import object as object_utils
+from pydantic import BaseModel, Field
 
-from . import BaseUnderscoreJsonPropsHandler
 from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
 
+T = TypeVar("T", bound="InMemoryEntity")
 
 class ValidationErrorCode:
     IN_MEMORY_ENTITY_DATA_INVALID = "IN_MEMORY_ENTITY_DATA_INVALID"
@@ -25,59 +25,25 @@ class EntityError(Exception):
         self.details = details
 
 
-class InMemoryEntity(BaseUnderscoreJsonPropsHandler):
-    jsonSchema: Optional[Dict] = None
 
+class InMemoryEntity(BaseModel):
+    jsonSchema: Optional[Dict[str, Any]] = Field(default=None, exclude=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    # --- Identity and Meta ---
     @classmethod
     def get_cls(cls) -> str:
         return cls.__name__
+
+    def get_cls_name(self) -> str:
+        return self.__class__.__name__
 
     @property
     def cls(self) -> str:
         return self.__class__.__name__
 
-    def get_cls_name(self) -> str:
-        return self.__class__.__name__
-
-    @classmethod
-    def create(cls, config: Dict[str, Any]) -> Any:
-        return cls(config)
-
-    def to_json(self, exclude: List[str] = []) -> Dict[str, Any]:
-        return self.clean(object_utils.clone_deep(object_utils.omit(self._json, exclude)))
-
-    def clone(self, extra_context: Dict[str, Any] = {}) -> Any:
-        config = self.to_json()
-        config.update(extra_context)
-        # To avoid:
-        #   Argument 1 to "__init__" of "BaseUnderscoreJsonPropsHandler" has incompatible type "Dict[str, Any]";
-        #   expected "BaseUnderscoreJsonPropsHandler"
-        return self.__class__(config)
-
-    @staticmethod
-    def validate_data(data: Dict[str, Any], clean: bool = False):
-        if clean:
-            print("Error: clean is not supported for InMemoryEntity.validateData")
-        if InMemoryEntity.jsonSchema:
-            jsonschema.validate(data, InMemoryEntity.jsonSchema)
-
-    def validate(self) -> None:
-        if self._json:
-            self.__class__.validate_data(self._json)
-
-    def clean(self, config: Dict[str, Any]) -> Dict[str, Any]:
-        # Not implemented, consider the below for the implementation
-        # https://stackoverflow.com/questions/44694835/remove-properties-from-json-object-not-present-in-schema
-        return config
-
-    def is_valid(self) -> bool:
-        try:
-            self.validate()
-            return True
-        except EntityError:
-            return False
-
-    # Properties
     @property
     def id(self) -> str:
         return self.prop("_id", "")
@@ -91,10 +57,56 @@ class InMemoryEntity(BaseUnderscoreJsonPropsHandler):
         return self.prop("slug", "")
 
     def get_as_entity_reference(self, by_id_only: bool = False) -> Dict[str, str]:
-        if by_id_only:
-            return {"_id": self.id}
-        else:
-            return {"_id": self.id, "slug": self.slug, "cls": self.get_cls_name()}
+        base = {"_id": self.id}
+        if not by_id_only:
+            base.update({"slug": self.slug, "cls": self.get_cls_name()})
+        return base
+
+    # --- Serialization ---
+    def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
+        return self.model_dump(exclude=set(exclude) if exclude else None)
+
+    def to_json(self, exclude: Optional[List[str]] = None) -> str:
+        return self.model_dump_json(exclude=set(exclude) if exclude else None)
+
+    # --- Instantiation ---
+    @classmethod
+    def create(cls: type[T], config: Dict[str, Any]) -> T:
+        return cls(**config)
+
+    def clone(self: T, extra_context: Optional[Dict[str, Any]] = None) -> T:
+        """Return a copy of this entity with optional updated fields."""
+        extra_context = extra_context or {}
+        return self.model_copy(update=extra_context)
+
+    # --- Validation ---
+    def validate(self) -> None:
+        if self._json and self.jsonSchema:
+            try:
+                jsonschema.validate(self._json, self.jsonSchema)
+            except jsonschema.exceptions.ValidationError as err:
+                raise EntityError(
+                    ValidationErrorCode.IN_MEMORY_ENTITY_DATA_INVALID,
+                    ErrorDetails(error=err, json=self._json, schema=self.jsonSchema),
+                )
+
+    @staticmethod
+    def validate_data(data: Dict[str, Any], clean: bool = False):
+        if clean:
+            raise NotImplementedError("clean=True not supported yet.")
+        if InMemoryEntity.jsonSchema:
+            jsonschema.validate(data, InMemoryEntity.jsonSchema)
+
+    def is_valid(self) -> bool:
+        try:
+            self.validate()
+            return True
+        except EntityError:
+            return False
+
+    def clean(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        # TODO: implement if needed, or use model_rebuild if schema evolves
+        return config
 
 
 class HasDescriptionHasMetadataNamedDefaultableInMemoryEntity(

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -1,14 +1,39 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
-import jsonschema
 from pydantic import BaseModel
 
 from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
 
-T = TypeVar("T", bound="InMemoryEntity")
+import jsonschema
+from mat3ra.utils import object as object_utils
+
+from . import BaseUnderscoreJsonPropsHandler
+
+T = TypeVar("T", bound="InMemoryEntityPydantic")
 
 
-class InMemoryEntity(BaseModel):
+# TODO: remove in the next PR
+class ValidationErrorCode:
+    IN_MEMORY_ENTITY_DATA_INVALID = "IN_MEMORY_ENTITY_DATA_INVALID"
+
+
+# TODO: remove in the next PR
+class ErrorDetails:
+    def __init__(self, error: Optional[Dict[str, Any]], json: Dict[str, Any], schema: Dict):
+        self.error = error
+        self.json = json
+        self.schema = schema
+
+
+# TODO: remove in the next PR
+class EntityError(Exception):
+    def __init__(self, code: ValidationErrorCode, details: Optional[ErrorDetails] = None):
+        super().__init__(code)
+        self.code = code
+        self.details = details
+
+
+class InMemoryEntityPydantic(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True
     }
@@ -20,10 +45,6 @@ class InMemoryEntity(BaseModel):
     def get_cls_name(self) -> str:
         return self.__class__.__name__
 
-    @property
-    def id(self) -> str:
-        return self.model_fields.get("_id", {}).get("default", "")
-
     def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
         return self.model_dump(exclude=set(exclude) if exclude else None)
 
@@ -32,7 +53,7 @@ class InMemoryEntity(BaseModel):
 
     @classmethod
     def create(cls: type[T], config: Dict[str, Any]) -> T:
-        return cls.model_validate(config)
+        return cls(**config)
 
     @classmethod
     def from_json(cls: type[T], json_str: str) -> T:
@@ -41,11 +62,81 @@ class InMemoryEntity(BaseModel):
     def clone(self: T, extra_context: Optional[Dict[str, Any]] = None) -> T:
         return self.model_copy(update=extra_context or {})
 
-    def validate_against_schema(self, schema: Dict[str, Any]) -> None:
-        jsonschema.validate(self.to_dict(), schema)
+
+# TODO: remove in the next PR
+class InMemoryEntity(BaseUnderscoreJsonPropsHandler):
+    jsonSchema: Optional[Dict] = None
+
+    @classmethod
+    def get_cls(cls) -> str:
+        return cls.__name__
+
+    @property
+    def cls(self) -> str:
+        return self.__class__.__name__
+
+    def get_cls_name(self) -> str:
+        return self.__class__.__name__
+
+    @classmethod
+    def create(cls, config: Dict[str, Any]) -> Any:
+        return cls(config)
+
+    def to_json(self, exclude: List[str] = []) -> Dict[str, Any]:
+        return self.clean(object_utils.clone_deep(object_utils.omit(self._json, exclude)))
+
+    def clone(self, extra_context: Dict[str, Any] = {}) -> Any:
+        config = self.to_json()
+        config.update(extra_context)
+        # To avoid:
+        #   Argument 1 to "__init__" of "BaseUnderscoreJsonPropsHandler" has incompatible type "Dict[str, Any]";
+        #   expected "BaseUnderscoreJsonPropsHandler"
+        return self.__class__(config)
+
+    @staticmethod
+    def validate_data(data: Dict[str, Any], clean: bool = False):
+        if clean:
+            print("Error: clean is not supported for InMemoryEntity.validateData")
+        if InMemoryEntity.jsonSchema:
+            jsonschema.validate(data, InMemoryEntity.jsonSchema)
+
+    def validate(self) -> None:
+        if self._json:
+            self.__class__.validate_data(self._json)
+
+    def clean(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        # Not implemented, consider the below for the implementation
+        # https://stackoverflow.com/questions/44694835/remove-properties-from-json-object-not-present-in-schema
+        return config
+
+    def is_valid(self) -> bool:
+        try:
+            self.validate()
+            return True
+        except EntityError:
+            return False
+
+    # Properties
+    @property
+    def id(self) -> str:
+        return self.prop("_id", "")
+
+    @id.setter
+    def id(self, id: str) -> None:
+        self.set_prop("_id", id)
+
+    @property
+    def slug(self) -> str:
+        return self.prop("slug", "")
+
+    def get_as_entity_reference(self, by_id_only: bool = False) -> Dict[str, str]:
+        if by_id_only:
+            return {"_id": self.id}
+        else:
+            return {"_id": self.id, "slug": self.slug, "cls": self.get_cls_name()}
 
 
-class HasDescriptionHasMetadataNamedDefaultableInMemoryEntity(
-    InMemoryEntity, DefaultableMixin, NamedMixin, HasMetadataMixin, HasDescriptionMixin
+class HasDescriptionHasMetadataNamedDefaultableInMemoryEntityPydantic(
+    InMemoryEntityPydantic, DefaultableMixin, NamedMixin, HasMetadataMixin, HasDescriptionMixin
 ):
     pass

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -1,38 +1,16 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
 import jsonschema
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
 
 T = TypeVar("T", bound="InMemoryEntity")
 
-class ValidationErrorCode:
-    IN_MEMORY_ENTITY_DATA_INVALID = "IN_MEMORY_ENTITY_DATA_INVALID"
-
-
-class ErrorDetails:
-    def __init__(self, error: Optional[Dict[str, Any]], json: Dict[str, Any], schema: Dict):
-        self.error = error
-        self.json = json
-        self.schema = schema
-
-
-class EntityError(Exception):
-    def __init__(self, code: ValidationErrorCode, details: Optional[ErrorDetails] = None):
-        super().__init__(code)
-        self.code = code
-        self.details = details
-
-
-
 class InMemoryEntity(BaseModel):
-    jsonSchema: Optional[Dict[str, Any]] = Field(default=None, exclude=True)
-
     class Config:
         arbitrary_types_allowed = True
 
-    # --- Identity and Meta ---
     @classmethod
     def get_cls(cls) -> str:
         return cls.__name__
@@ -41,72 +19,34 @@ class InMemoryEntity(BaseModel):
         return self.__class__.__name__
 
     @property
-    def cls(self) -> str:
-        return self.__class__.__name__
-
-    @property
     def id(self) -> str:
-        return self.prop("_id", "")
-
-    @id.setter
-    def id(self, id: str) -> None:
-        self.set_prop("_id", id)
-
-    @property
-    def slug(self) -> str:
-        return self.prop("slug", "")
+        return self.model_fields.get("_id", {}).get("default", "")
 
     def get_as_entity_reference(self, by_id_only: bool = False) -> Dict[str, str]:
         base = {"_id": self.id}
         if not by_id_only:
-            base.update({"slug": self.slug, "cls": self.get_cls_name()})
+            base.update({"cls": self.get_cls_name()})
         return base
 
-    # --- Serialization ---
     def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
         return self.model_dump(exclude=set(exclude) if exclude else None)
 
     def to_json(self, exclude: Optional[List[str]] = None) -> str:
         return self.model_dump_json(exclude=set(exclude) if exclude else None)
 
-    # --- Instantiation ---
     @classmethod
     def create(cls: type[T], config: Dict[str, Any]) -> T:
-        return cls(**config)
+        return cls.model_validate(config)
+
+    @classmethod
+    def from_json(cls: type[T], json_str: str) -> T:
+        return cls.model_validate_json(json_str)
 
     def clone(self: T, extra_context: Optional[Dict[str, Any]] = None) -> T:
-        """Return a copy of this entity with optional updated fields."""
-        extra_context = extra_context or {}
-        return self.model_copy(update=extra_context)
+        return self.model_copy(update=extra_context or {})
 
-    # --- Validation ---
-    def validate(self) -> None:
-        if self._json and self.jsonSchema:
-            try:
-                jsonschema.validate(self._json, self.jsonSchema)
-            except jsonschema.exceptions.ValidationError as err:
-                raise EntityError(
-                    ValidationErrorCode.IN_MEMORY_ENTITY_DATA_INVALID,
-                    ErrorDetails(error=err, json=self._json, schema=self.jsonSchema),
-                )
-
-    @staticmethod
-    def validate_data(data: Dict[str, Any], clean: bool = False):
-        if clean:
-            raise NotImplementedError("clean=True not supported yet.")
-        if InMemoryEntity.jsonSchema:
-            jsonschema.validate(data, InMemoryEntity.jsonSchema)
-
-    def is_valid(self) -> bool:
-        try:
-            self.validate()
-            return True
-        except EntityError:
-            return False
-
-    def clean(self, config: Dict[str, Any]) -> Dict[str, Any]:
-        # TODO: implement if needed, or use model_rebuild if schema evolves
-        return config
+    def validate_against_schema(self, schema: Dict[str, Any]) -> None:
+        jsonschema.validate(self.to_dict(), schema)
 
 
 class HasDescriptionHasMetadataNamedDefaultableInMemoryEntity(

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -37,12 +37,20 @@ class InMemoryEntityPydantic(BaseModel):
 
     @classmethod
     def create(cls: Type[T], config: Dict[str, Any]) -> T:
-        validated_data = cls.clean(config)
-        return cls(**validated_data)
+        return cls.validate(**config)
 
     @classmethod
     def validate(cls, value: Any) -> Self:
+        # this will clean and validate data
         return cls.model_validate(value)
+
+    @classmethod
+    def is_valid(cls, value: Any) -> bool:
+        try:
+            cls.validate(value)
+            return True
+        except Exception:
+            return False
 
     @classmethod
     def from_json(cls: Type[T], json_str: str) -> T:

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -50,7 +50,7 @@ class InMemoryEntityPydantic(BaseModel):
 
     @classmethod
     def clean(cls: Type[T], config: Dict[str, Any]) -> Dict[str, Any]:
-        validated_model = cls.validated_model_validate(config)
+        validated_model = cls.model_validate(config)
         return validated_model.model_dump()
 
     def get_cls_name(self) -> str:

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -33,10 +33,7 @@ class EntityError(Exception):
 
 
 class InMemoryEntityPydantic(BaseModel):
-    model_config = {"arbitrary_types_allowed": True, "extra": "allow"}
-
-    # Factory helper field mapping field names to class names
-    _class_factory: Dict = {}
+    model_config = {"arbitrary_types_allowed": True}
 
     @classmethod
     def create(cls: Type[T], config: Dict[str, Any]) -> T:
@@ -63,18 +60,6 @@ class InMemoryEntityPydantic(BaseModel):
     def clean(cls: Type[T], config: Dict[str, Any]) -> Dict[str, Any]:
         validated_model = cls.model_validate(config)
         return validated_model.model_dump()
-
-    def model_post_init(self, __context: Any) -> None:
-        for field_name, field_value in self.__dict__.items():
-            if isinstance(field_value, BaseModel):
-                class_reference = self._class_factory.get(field_name)
-                if not class_reference:
-                    continue
-                else:
-                    instance_field_name = field_name + "_instance"
-                    config = field_value.model_dump()  # convert from BaseModel to dict
-                    class_instance = class_reference(**config)
-                    setattr(self, instance_field_name, class_instance)
 
     def get_cls_name(self) -> str:
         return self.__class__.__name__

--- a/src/py/mat3ra/code/entity.py
+++ b/src/py/mat3ra/code/entity.py
@@ -9,6 +9,7 @@ from . import BaseUnderscoreJsonPropsHandler
 from .mixins import DefaultableMixin, HasDescriptionMixin, HasMetadataMixin, NamedMixin
 
 T = TypeVar("T", bound="InMemoryEntityPydantic")
+B = TypeVar("B", bound="BaseModel")
 
 
 # TODO: remove in the next PR
@@ -60,6 +61,15 @@ class InMemoryEntityPydantic(BaseModel):
     def clean(cls: Type[T], config: Dict[str, Any]) -> Dict[str, Any]:
         validated_model = cls.model_validate(config)
         return validated_model.model_dump()
+
+    def get_schema(self) -> Dict[str, Any]:
+        return self.model_json_schema()
+
+    def get_data_model(self) -> Type[B]:
+        for base in self.__class__.__bases__:
+            if issubclass(base, BaseModel) and base is not self.__class__:
+                return base  # this will be MaterialSchema
+        raise ValueError(f"No schema base model found for {self.__class__.__name__}")
 
     def get_cls_name(self) -> str:
         return self.__class__.__name__

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -3,6 +3,8 @@ from typing import Any, ClassVar, Dict, Optional
 from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 from mat3ra.esse.models.system.description import DescriptionSchema
 from mat3ra.esse.models.system.metadata import MetadataSchema
+from mat3ra.esse.models.system.name import NameEntitySchema
+
 from pydantic import BaseModel
 
 
@@ -20,8 +22,8 @@ class DefaultableMixin(DefaultableEntitySchema):
         return instance
 
 
-class NamedMixin(BaseModel):
-    name: Optional[str] = None
+class NamedMixin(NameEntitySchema):
+    pass
 
 
 class HasMetadataMixin(MetadataSchema):

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -7,11 +7,11 @@ from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 
 
 class DefaultableMixin(DefaultableEntitySchema):
-    __default_config__: [Dict[str, Any]] = {}
+    default_config: [Dict[str, Any]] = {}
 
     @classmethod
     def create_default(cls) -> "DefaultableMixin":
-        return cls.model_validate(cls.__default_config__)
+        return cls(**cls.default_config)
 
 
 class NamedMixin(BaseModel):

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -4,7 +4,6 @@ from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 from mat3ra.esse.models.system.description import DescriptionSchema
 from mat3ra.esse.models.system.metadata import MetadataSchema
 from mat3ra.esse.models.system.name import NameEntitySchema
-
 from pydantic import BaseModel
 
 

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -7,7 +7,7 @@ from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 
 
 class DefaultableMixin(DefaultableEntitySchema):
-    default_config: [Dict[str, Any]] = {}
+    default_config: Dict[str, Any] = {}
 
     @classmethod
     def create_default(cls) -> "DefaultableMixin":

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -1,57 +1,26 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from .. import BaseUnderscoreJsonPropsHandler
+from mat3ra.esse.models.system.description import DescriptionSchema
+from mat3ra.esse.models.system.metadata import MetadataSchema
+from pydantic import BaseModel
+from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 
 
-class DefaultableMixin(BaseUnderscoreJsonPropsHandler):
-    __default_config__: Dict[str, Any]
-
-    @property
-    def is_default(self) -> bool:
-        return self.get_prop("isDefault", False)
-
-    @is_default.setter
-    def is_default(self, is_default: bool = False) -> None:
-        self.set_prop("isDefault", is_default)
+class DefaultableMixin(DefaultableEntitySchema):
+    __default_config__: [Dict[str, Any]] = {}
 
     @classmethod
     def create_default(cls) -> "DefaultableMixin":
-        return cls(cls.__default_config__)
+        return cls.model_validate(cls.__default_config__)
 
 
-class NamedMixin(BaseUnderscoreJsonPropsHandler):
-    @property
-    def name(self) -> str:
-        return self.get_prop("name", False)
-
-    @name.setter
-    def name(self, name: str = "") -> None:
-        self.set_prop("name", name)
+class NamedMixin(BaseModel):
+    name: Optional[str] = None
 
 
-class HasMetadataMixin(BaseUnderscoreJsonPropsHandler):
-    @property
-    def metadata(self) -> Dict:
-        return self.get_prop("metadata", False)
-
-    @metadata.setter
-    def metadata(self, metadata: Dict = {}) -> None:
-        self.set_prop("metadata", metadata)
+class HasMetadataMixin(MetadataSchema):
+    pass
 
 
-class HasDescriptionMixin(BaseUnderscoreJsonPropsHandler):
-    @property
-    def description(self) -> str:
-        return self.get_prop("description", "")
-
-    @description.setter
-    def description(self, description: str = "") -> None:
-        self.set_prop("description", description)
-
-    @property
-    def description_object(self) -> str:
-        return self.get_prop("descriptionObject", "")
-
-    @description_object.setter
-    def description_object(self, description_object: str = "") -> None:
-        self.set_prop("descriptionObject", description_object)
+class HasDescriptionMixin(DescriptionSchema):
+    pass

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional, ClassVar
+from typing import Any, ClassVar, Dict, Optional
 
+from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 from mat3ra.esse.models.system.description import DescriptionSchema
 from mat3ra.esse.models.system.metadata import MetadataSchema
 from pydantic import BaseModel
-from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 
 
 class DefaultableMixin(DefaultableEntitySchema):
@@ -14,7 +14,7 @@ class DefaultableMixin(DefaultableEntitySchema):
         return self.__default_config__
 
     @classmethod
-    def create_default(cls) -> "DefaultablePydanticMixin":
+    def create_default(cls) -> "DefaultableMixin":
         instance = cls(**cls.__default_config__)
         instance.isDefault = True
         return instance

--- a/src/py/mat3ra/code/mixins/__init__.py
+++ b/src/py/mat3ra/code/mixins/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, ClassVar
 
 from mat3ra.esse.models.system.description import DescriptionSchema
 from mat3ra.esse.models.system.metadata import MetadataSchema
@@ -7,11 +7,17 @@ from mat3ra.esse.models.system.defaultable import DefaultableEntitySchema
 
 
 class DefaultableMixin(DefaultableEntitySchema):
-    default_config: Dict[str, Any] = {}
+    __default_config__: ClassVar[Dict[str, Any]] = {}
+
+    @property
+    def default_config(self) -> Dict[str, Any]:
+        return self.__default_config__
 
     @classmethod
-    def create_default(cls) -> "DefaultableMixin":
-        return cls(**cls.default_config)
+    def create_default(cls) -> "DefaultablePydanticMixin":
+        instance = cls(**cls.__default_config__)
+        instance.isDefault = True
+        return instance
 
 
 class NamedMixin(BaseModel):

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -39,6 +39,49 @@ def test_validate():
         assert True  # Expecting an exception for invalid input
 
 
+def test_is_valid():
+    assert ExampleClass.is_valid(REFERENCE_OBJECT_VALID) is True
+    assert ExampleClass.is_valid(REFERENCE_OBJECT_INVALID) is False
+
+
+def test_from_json():
+    # Test from_json method with valid JSON
+    in_memory_entity = ExampleClass.from_json(REFERENCE_OBJECT_VALID_JSON)
+    assert isinstance(in_memory_entity, ExampleClass)
+    assert in_memory_entity.key1 == "value1"
+    assert in_memory_entity.key2 == 1
+
+    # Test from_json with invalid JSON
+    try:
+        _ = ExampleClass.from_json(json.dumps(REFERENCE_OBJECT_INVALID))
+        assert False, "Invalid JSON did not raise an exception"
+    except Exception:
+        assert True  # Expecting an exception for invalid JSON
+
+
+def test_clean():
+    # Test clean method with valid input
+    cleaned_data = ExampleClass.clean(REFERENCE_OBJECT_VALID)
+    assert isinstance(cleaned_data, dict)
+    assert cleaned_data == REFERENCE_OBJECT_VALID
+
+    # Test clean method with invalid input
+    try:
+        _ = ExampleClass.clean(REFERENCE_OBJECT_INVALID)
+        assert False, "Invalid input did not raise an exception"
+    except Exception:
+        assert True  # Expecting an exception for invalid input
+
+
+def test_get_cls_name():
+    # Test get_cls_name method
+    entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+    cls_name = entity.get_cls_name()
+    assert cls_name == "ExampleClass", f"Expected 'ExampleClass', got '{cls_name}'"
+    # Ensure it works for the class itself
+    assert ExampleClass.__name__ == "ExampleClass"
+
+
 def test_to_dict():
     entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
     # Test to_dict method
@@ -52,7 +95,22 @@ def test_to_dict():
 
 def test_to_json():
     entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
-
     result = entity.to_json()
     assert isinstance(result, str)
     assert json.loads(result) == json.loads(REFERENCE_OBJECT_VALID_JSON)
+
+
+def test_clone():
+    entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+    # Test clone method
+    cloned_entity = entity.clone()
+    assert isinstance(cloned_entity, ExampleClass)
+    assert cloned_entity.key1 == entity.key1
+    assert cloned_entity.key2 == entity.key2
+
+    # Test clone with extra context
+    extra_context = {"key2": 2}
+    cloned_entity_with_extra = entity.clone(extra_context=extra_context)
+    assert isinstance(cloned_entity_with_extra, ExampleClass)
+    assert cloned_entity_with_extra.key1 == entity.key1
+    assert cloned_entity_with_extra.key2 == 2  # Should override to 2

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -2,23 +2,27 @@ from mat3ra.code.entity import InMemoryEntity
 
 REFERENCE_OBJECT_1 = {"key1": "value1", "key2": "value2"}
 
+class ChildClass(InMemoryEntity):
+    key1: str
+    key2: str
+
+child_object = ChildClass(**REFERENCE_OBJECT_1)
 
 def test_create():
     in_memory_entity = InMemoryEntity.create({})
     assert isinstance(in_memory_entity, InMemoryEntity)
 
 
-def test_get_prop():
-    in_memory_entity = InMemoryEntity.create(REFERENCE_OBJECT_1)
-    assert in_memory_entity.get_prop("key1") == "value1"
+def test_subclass_fields():
+    assert child_object.key1 == "value1"
+    assert child_object.key2 == "value2"
 
 
-def test_set_prop():
-    in_memory_entity = InMemoryEntity.create(REFERENCE_OBJECT_1)
-    in_memory_entity.set_prop("key3", "value3")
-    assert in_memory_entity.get_prop("key3") == "value3"
+def test_to_dict():
+    entity = child_object.create(REFERENCE_OBJECT_1)
+    assert entity.to_dict() == REFERENCE_OBJECT_1
 
 
 def test_to_json():
-    in_memory_entity = InMemoryEntity.create({})
-    assert in_memory_entity.to_json() == {}
+    entity = child_object.create(REFERENCE_OBJECT_1)
+    assert entity.to_json() == '{"key1":"value1","key2":"value2"}'

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from mat3ra.code.entity import InMemoryEntityPydantic
 from pydantic import BaseModel
@@ -23,7 +24,10 @@ class ExampleClass(ExampleSchema, InMemoryEntityPydantic):
 
 
 class ExampleNestedClass(ExampleNestedSchema, InMemoryEntityPydantic):
-    _class_factory = {"nested_key1": ExampleClass}
+
+    @property
+    def nested_key1_instance(self) -> ExampleClass:
+        return ExampleClass.create(self.nested_key1.model_dump())
 
 
 example_class_instance_valid = ExampleClass(**REFERENCE_OBJECT_VALID)

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -1,31 +1,58 @@
+import json
+
 from mat3ra.code.entity import InMemoryEntityPydantic
+from pydantic import BaseModel
 
-REFERENCE_OBJECT_1 = {"key1": "value1", "key2": "value2"}
+REFERENCE_OBJECT_VALID = {"key1": "value1", "key2": 1}
+REFERENCE_OBJECT_INVALID = {"key1": "value1", "key2": "value2"}
+REFERENCE_OBJECT_VALID_JSON = json.dumps(REFERENCE_OBJECT_VALID)
 
 
-class ChildClass(InMemoryEntityPydantic):
+class ExampleSchema(BaseModel):
     key1: str
-    key2: str
+    key2: int
 
 
-child_object = ChildClass(**REFERENCE_OBJECT_1)
+class ExampleClass(ExampleSchema, InMemoryEntityPydantic):
+    pass
+
+
+example_class_instance_valid = ExampleClass(**REFERENCE_OBJECT_VALID)
 
 
 def test_create():
-    in_memory_entity = InMemoryEntityPydantic.create({})
-    assert isinstance(in_memory_entity, InMemoryEntityPydantic)
+    in_memory_entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+    assert isinstance(in_memory_entity, ExampleClass)
+    assert in_memory_entity.key1 == "value1"
+    assert in_memory_entity.key2 == 1
 
 
-def test_subclass_fields():
-    assert child_object.key1 == "value1"
-    assert child_object.key2 == "value2"
+def test_validate():
+    # Test valid case
+    in_memory_entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+    assert isinstance(in_memory_entity, ExampleClass)
+    # Test invalid case
+    try:
+        _ = ExampleClass.create(REFERENCE_OBJECT_INVALID)
+        assert False, "Invalid input did not raise an exception"
+    except Exception as e:
+        assert True  # Expecting an exception for invalid input
 
 
 def test_to_dict():
-    entity = child_object.create(REFERENCE_OBJECT_1)
-    assert entity.to_dict() == REFERENCE_OBJECT_1
+    entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+    # Test to_dict method
+    result = entity.to_dict()
+    assert isinstance(result, dict)
+    assert result == {"key1": "value1", "key2": 1}
+    # Test with exclude
+    result_exclude = entity.to_dict(exclude=["key2"])
+    assert result_exclude == {"key1": "value1"}
 
 
 def test_to_json():
-    entity = child_object.create(REFERENCE_OBJECT_1)
-    assert entity.to_json() == '{"key1":"value1","key2":"value2"}'
+    entity = ExampleClass.create(REFERENCE_OBJECT_VALID)
+
+    result = entity.to_json()
+    assert isinstance(result, str)
+    assert json.loads(result) == json.loads(REFERENCE_OBJECT_VALID_JSON)

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -35,7 +35,6 @@ class ExampleNestedClass(ExampleNestedSchema, InMemoryEntityPydantic):
 
 class ExampleFullClass(ExampleOverrideSchema, InMemoryEntityPydantic):
     __default_config__ = REFERENCE_OBJECT_OVERRIDE_VALID
-    __schema__ = ExampleOverrideSchema
 
     # We override the as_class_instance field to be an instance of ExampleClass
     as_class_instance: ExampleClass = ExampleClass(**REFERENCE_OBJECT_VALID)
@@ -64,7 +63,7 @@ def test_full_class():
     assert isinstance(in_memory_entity.as_class_instance, ExampleClass)
     assert in_memory_entity.as_class_instance.key1 == "value1"
     assert in_memory_entity.as_class_instance.key2 == 1
-    assert in_memory_entity.__schema__ == ExampleOverrideSchema
+    assert in_memory_entity.get_data_model() == ExampleOverrideSchema
 
 
 def test_validate():

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -1,16 +1,19 @@
-from mat3ra.code.entity import InMemoryEntity
+from mat3ra.code.entity import InMemoryEntityPydantic
 
 REFERENCE_OBJECT_1 = {"key1": "value1", "key2": "value2"}
 
-class ChildClass(InMemoryEntity):
+
+class ChildClass(InMemoryEntityPydantic):
     key1: str
     key2: str
 
+
 child_object = ChildClass(**REFERENCE_OBJECT_1)
 
+
 def test_create():
-    in_memory_entity = InMemoryEntity.create({})
-    assert isinstance(in_memory_entity, InMemoryEntity)
+    in_memory_entity = InMemoryEntityPydantic.create({})
+    assert isinstance(in_memory_entity, InMemoryEntityPydantic)
 
 
 def test_subclass_fields():

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 from mat3ra.code.entity import InMemoryEntityPydantic
 from pydantic import BaseModel
@@ -24,7 +23,6 @@ class ExampleClass(ExampleSchema, InMemoryEntityPydantic):
 
 
 class ExampleNestedClass(ExampleNestedSchema, InMemoryEntityPydantic):
-
     @property
     def nested_key1_instance(self) -> ExampleClass:
         return ExampleClass.create(self.nested_key1.model_dump())

--- a/tests/py/unit/test_entity.py
+++ b/tests/py/unit/test_entity.py
@@ -35,7 +35,7 @@ def test_validate():
     try:
         _ = ExampleClass.create(REFERENCE_OBJECT_INVALID)
         assert False, "Invalid input did not raise an exception"
-    except Exception as e:
+    except Exception:
         assert True  # Expecting an exception for invalid input
 
 

--- a/tests/py/unit/test_mixins.py
+++ b/tests/py/unit/test_mixins.py
@@ -1,0 +1,34 @@
+from mat3ra.code.mixins import DefaultableMixin, NamedMixin
+
+
+def test_defaultable_mixin():
+    # Test the DefaultableMixin functionality
+    default_config = {"key": "value", "number": 42}
+
+    class ExampleDefaultable(DefaultableMixin):
+        key: str
+        number: int
+
+        __default_config__ = default_config
+
+    # Create a default instance
+    instance = ExampleDefaultable.create_default()
+
+    assert instance.key == "value"
+    assert instance.number == 42
+    assert hasattr(instance, 'isDefault') and instance.isDefault is True
+
+
+def test_named_mixin():
+    # Test the NamedMixin functionality
+    class ExampleNamed(NamedMixin):
+        pass
+
+    # Create an instance with a name
+    instance = ExampleNamed(name="TestName")
+
+    assert instance.name == "TestName"
+
+    # Test with None
+    instance_none = ExampleNamed()
+    assert instance_none.name is None

--- a/tests/py/unit/test_mixins.py
+++ b/tests/py/unit/test_mixins.py
@@ -16,7 +16,7 @@ def test_defaultable_mixin():
 
     assert instance.key == "value"
     assert instance.number == 42
-    assert hasattr(instance, 'isDefault') and instance.isDefault is True
+    assert hasattr(instance, "isDefault") and instance.isDefault is True
 
 
 def test_named_mixin():


### PR DESCRIPTION
start using Pydantic via BaseModel and Model classes coming from ESSE

First PR:
code: switches to use Pydantic for Mixins and InMemoryEntity (for now with temporary suffix Pydantic) and keep two classes in parallel.